### PR TITLE
Add some debugging output when passing -v

### DIFF
--- a/src/Commands/MergeLatestTagCommand.php
+++ b/src/Commands/MergeLatestTagCommand.php
@@ -56,6 +56,13 @@ class MergeLatestTagCommand extends PrMergeCommand
             ]
         );
 
+        if ($input->getOption('verbose')) {
+            $output->writeln('Response:');
+            $output->writeLn('  Status: '.$response->getStatusCode());
+            $output->writeLn('  Body: '.$response->getBody()->getContents());
+            $output->writeLn('');
+        }
+
         $release = json_decode($response->getBody(), true);
 
         return $this->call($input, $output, [

--- a/src/Commands/PrMergeCommand.php
+++ b/src/Commands/PrMergeCommand.php
@@ -101,7 +101,7 @@ class PrMergeCommand extends Command
 
         // Construct and execute the request.
         $client = new Client();
-        $client->post(
+        $response = $client->post(
             $_ENV['DESTINATION_URL'],
             [
                 'body' => $payload,
@@ -112,7 +112,12 @@ class PrMergeCommand extends Command
                 ],
             ]
         );
-
+        if ($input->getOption('verbose')) {
+            $output->writeln('Response:');
+            $output->writeLn('  Status: '.$response->getStatusCode());
+            $output->writeLn('  Body: '.$response->getBody()->getContents());
+            $output->writeLn('');
+        }
         $output->writeLn('Done.');
 
         return 0;

--- a/src/Commands/PublishReleaseCommand.php
+++ b/src/Commands/PublishReleaseCommand.php
@@ -81,7 +81,7 @@ class PublishReleaseCommand extends Command
 
         // Construct and execute the request.
         $client = new Client();
-        $client->post(
+        $response = $client->post(
             $_ENV['DESTINATION_URL'],
             [
                 'body' => $payload,
@@ -92,6 +92,13 @@ class PublishReleaseCommand extends Command
                 ],
             ]
         );
+
+        if ($input->getOption('verbose')) {
+            $output->writeln('Response:');
+            $output->writeLn('  Status: '.$response->getStatusCode());
+            $output->writeLn('  Body: '.$response->getBody()->getContents());
+            $output->writeLn('');
+        }
 
         $output->writeLn('Done.');
 


### PR DESCRIPTION
When passing -v option, show some debugging output to debug potential issues with the GH Api/Webhooks API request